### PR TITLE
メモ作成実装

### DIFF
--- a/frontend/src/app/todo/todo.component.html
+++ b/frontend/src/app/todo/todo.component.html
@@ -1,1 +1,43 @@
-<p>todo works!</p>
+<div class="box">
+  <h1>メモ作成</h1>
+
+  <div class="todo-form">
+    <form [formGroup]="todoForm">
+      <h2>タイトル</h2>
+      <input type="hidden" formControlName="id" />
+      <input
+        matInput
+        type="text"
+        formControlName="title"
+        [ngClass]="{
+          'invalid-form': checkTitle
+        }"
+      />
+      <textarea
+        matInput
+        formControlName="memo"
+        [ngClass]="{
+          'invalid-form': checkMemo
+        }"
+      >
+      </textarea>
+    </form>
+  </div>
+
+  <div class="button-area">
+    <div class="left-side">
+      <button (click)="backToList()">戻る</button>
+    </div>
+    <div class="right-side">
+      <button
+        (click)="saveMemo()"
+        [disabled]="todoForm.invalid"
+        [ngClass]="{
+          'invalid-button': todoForm.invalid
+        }"
+      >
+        保存
+      </button>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/todo/todo.component.scss
+++ b/frontend/src/app/todo/todo.component.scss
@@ -1,0 +1,90 @@
+h1 {
+  border: 1px solid black;
+  margin: 2% auto;
+  text-align: center;
+  width: 80%;
+}
+
+.box {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+button {
+  font-size: 16px;
+  height: 60px;
+  width: 90px;
+}
+
+.button-area {
+  margin-top: 3%;
+  text-align: center;
+  width: 80%;
+
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+/* 各ボタンエリアの幅を調整 */
+.button-area > div {
+  width: 50%;
+  display: flex;
+  justify-content: center; /* 中央揃えに変更 */
+  gap: 10px;
+
+  &.left-side {
+    justify-content: flex-start; /* 左揃えに変更 */
+  }
+
+  &.right-side {
+    justify-content: flex-end; /* 右揃えに変更 */
+  }
+}
+
+.button-area button {
+  margin-right: 5px;
+}
+
+/* バリデーションエラー用スタイル */
+.invalid-form {
+  border: 1px solid red;
+}
+
+.invalid-button {
+  border: 1px solid silver;
+  color: silver;
+  font-weight: bold;
+}
+
+/* 入力フォームスタイル */
+.todo-form {
+  margin: 0 auto;
+  width: 80%;
+
+  h2 {
+    border: 1px solid black;
+    box-sizing: border-box;
+    font-size: x-large;
+    height: 32px;
+    margin-bottom: -1px;
+    text-align: center;
+    width: 100%;
+  }
+
+  input,
+  textarea {
+    box-sizing: border-box;
+    display: inline-block;
+    flex-direction: column;
+    font-size: x-large;
+    resize: vertical;
+    width: 100%;
+  }
+
+  textarea {
+    height: 230px;
+    margin-top: -1px;
+  }
+}

--- a/frontend/src/app/todo/todo.component.ts
+++ b/frontend/src/app/todo/todo.component.ts
@@ -1,10 +1,95 @@
-import { Component } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { MatInputModule } from '@angular/material/input';
+import {
+  FormControl,
+  FormGroup,
+  FormsModule,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { NgClass } from '@angular/common';
+import { DUMMY_DATA } from '../dummy-data';
 
 @Component({
   selector: 'app-todo',
   standalone: true,
-  imports: [],
+  imports: [NgClass, FormsModule, MatInputModule, ReactiveFormsModule],
   templateUrl: './todo.component.html',
   styleUrl: './todo.component.scss',
 })
-export default class TodoComponent {}
+export default class TodoComponent implements OnInit {
+  router = inject(Router);
+  route = inject(ActivatedRoute);
+  mode: string = 'new';
+  memoId = 0;
+  dummyData = DUMMY_DATA;
+
+  todoForm = new FormGroup({
+    id: new FormControl<number | null>(null),
+    title: new FormControl<string>('', {
+      validators: [
+        Validators.required,
+        Validators.minLength(1),
+        Validators.maxLength(32),
+      ],
+    }),
+    memo: new FormControl<string>('', {
+      validators: [
+        Validators.required,
+        Validators.minLength(1),
+        Validators.maxLength(1024),
+      ],
+    }),
+  });
+
+  get checkTitle(): boolean {
+    const isTitle =
+      this.todoForm.get('title')?.invalid &&
+      (this.todoForm.get('title')?.dirty ||
+        this.todoForm.get('title')?.touched);
+    return isTitle == null ? true : isTitle;
+  }
+
+  get checkMemo(): boolean {
+    const isTitle =
+      this.todoForm.get('memo')?.invalid &&
+      (this.todoForm.get('memo')?.dirty || this.todoForm.get('memo')?.touched);
+    return isTitle == null ? true : isTitle;
+  }
+
+  ngOnInit(): void {
+    if (this.route.snapshot.paramMap.get('id') == null) {
+      // 新規作成処理
+      this.mode = 'new';
+    } else {
+      // 編集処理
+      this.mode = 'edit';
+      this.memoId = Number(this.route.snapshot.paramMap.get('id'));
+      const target = this.dummyData.filter(
+        (memo) => memo.id === this.memoId
+      )[0];
+
+      this.todoForm.patchValue({
+        id: this.memoId,
+        title: target.title,
+        memo: target.memo,
+      });
+    }
+  }
+
+  backToList(): void {
+    // ブラウザバックで戻る
+    history.back();
+  }
+
+  saveMemo(): void {
+    const startMsg = this.mode === 'new' ? '新規作成します。' : '更新します。';
+    const msg = startMsg + 'よろしいですか？';
+    if (window.confirm(msg)) {
+      // TODO: API 実装予定
+      // 現時点では画面遷移のみ
+      this.router.navigate(['/']);
+    }
+  }
+}


### PR DESCRIPTION
### メモ作成画面機能実装 4cc54f2

> [!NOTE]
> - DI （[依存性の注入](https://ja.wikipedia.org/wiki/%E4%BE%9D%E5%AD%98%E6%80%A7%E3%81%AE%E6%B3%A8%E5%85%A5#:~:text=%E4%BE%9D%E5%AD%98%E6%80%A7%E3%81%AE%E6%B3%A8%E5%85%A5%EF%BC%88%E3%81%84,DI%E3%81%A8%E7%95%A5%E3%81%95%E3%82%8C%E3%82%8B%E3%80%82)）：Dependency injection
> - [Angularにおける依存性の注入](https://angular.jp/guide/dependency-injection-overview#:~:text=%E4%BE%9D%E5%AD%98%E6%80%A7%E3%81%AE%E6%B3%A8%E5%85%A5%EF%BC%88DI,%E9%AB%98%E3%82%81%E3%82%8B%E3%81%93%E3%81%A8%E3%81%8C%E3%81%A7%E3%81%8D%E3%81%BE%E3%81%99%E3%80%82)
> - `Route`は、URLとそれに対応するコンポーネントやアクションのマッピングを定義します。
> - `ActivatedRoute`は現在のURLに関する情報取得できる命令です。
> - 参考：[ルーターチュートリアル：ツアーオブヒーローズ](https://angular.jp/guide/router-tutorial-toh)
> - 入力 UI には、Angular の[リアクティブフォーム](https://angular.jp/guide/reactive-forms) を使います。
> - 入力チェックには、[フォーム入力のバリデーション](https://angular.jp/guide/form-validation)を使います。

```ts
  // Angular の Router をこのコンポーネントに DI （依存注入）します。
  router = inject(Router);

  // Angular の ActivatedRoute をこのコンポーネントに DI （依存注入）します。
  route = inject(ActivatedRoute);

  // 新規作成か編集かを識別する文字列
  mode: string = 'new';

  // 編集時に必要になるメモの id 
  memoId = 0;

  // DUMMY_DATA を dummyData に代入
  dummyData = DUMMY_DATA; 

  // メモ作成用のフォーム定義
  todoForm = new FormGroup({
    // メモ id ：新規作成の時は、null の想定
    id: new FormControl<number | null>(null),
    // メモタイトル：新規作成の時は、空文字の想定
    title: new FormControl<string>('', {
      // メモタイトル用バリデーション：必須、最小 1 文字、最大 32 文字
      validators: [
        Validators.required,
        Validators.minLength(1),
        Validators.maxLength(32),
      ],
    }),
    // メモ：新規作成の時は、空文字の想定
    memo: new FormControl<string>('', {
      // メモ用バリデーション：必須、最小 1 文字、最大 1024 文字
      validators: [
        Validators.required,
        Validators.minLength(1),
        Validators.maxLength(1024),
      ],
    }),
  });
```

#### 入力バリデーション

- メモタイトル、メモのバリデーション条件外の時は、入力エラーモードになります。
- 必須項目未入力、上限文字数以上の入力

#### URL パラメータ取得
> [!NOTE]
> - Angular の `ngOnInit` は、コンポーネントが初期化される際に実行される特別なメソッドです。
> - [コンポーネントのライフサイクル](https://angular.jp/guide/lifecycle-hooks)


- 新規作成時の URL：https://サーバー名/`new`
- 編集時の URL：https://サーバー名/`id`
  - メモ id

```ts
  ngOnInit(): void {
    // URL に id が無い時は、新規作成
    if (this.route.snapshot.paramMap.get('id') == null) {
      // 新規作成処理
      this.mode = 'new';
    // URL に id が有る時は、編集
    } else {
      // 編集処理
      // モードを編集に変更
      this.mode = 'edit';
      // URL の id は文字列なので、数値に変換
      this.memoId = Number(this.route.snapshot.paramMap.get('id'));
      // 取得した id 基にデータを抽出　※ダミーデータ専用処理です
      const target = this.dummyData.filter(
        (memo) => memo.id === this.memoId
      )[0];

      // 取得した id 基にデータを抽出　※ダミーデータ専用処理です
      this.todoForm.patchValue({
        id: this.memoId,
        title: target.title,
        memo: target.memo,
      });
    }
  }
```

#### 保存
> [!NOTE]
> この段階では、画面遷移とメッセージ表示処理`のみ`の実装です。

```ts
  saveMemo(): void {
    // 編集モードで、表示する文字列を変更します。
    const startMsg = this.mode === 'new' ? '新規作成します。' : '更新します。';
    const msg = startMsg + 'よろしいですか？';
    if (window.confirm(msg)) {
      // TODO: API 実装予定
      // 現時点では画面遷移のみ
      this.router.navigate(['/']);
    }
  }
```

#### 戻る
> [!NOTE]
> ウェブブラウザーの標準命令の [`history.back`](https://developer.mozilla.org/ja/docs/Web/API/History/back) を使います。

```ts
  backToList(): void {
    // ブラウザバックで戻る
    history.back();
  }
```


### メモ作成画面スタイル実装 6200b04

#### スタイル割当

- 各 html タグや、class 属性に割り当てたクラス名を実装します。

### メモ作成画面 html 実装 c0c95a3
#### 入力フォーム配置

> [!NOTE]
> [NgClass](https://angular.jp/api/common/NgClass)
> [バインディングタイプとターゲット](https://angular.jp/guide/binding-syntax)

- checkTitle が true の時、入力エラー状態の場合、`NgClass` を使って赤枠のスタイルを付与します
- checkMemo が true の時、入力エラー状態で、`NgClass` を使って赤枠のスタイルを付与します

```html
    <form [formGroup]="todoForm">
      <h2>タイトル</h2>
      <!-- 隠し項目：メモ id -->
      <input type="hidden" formControlName="id" />
      <!-- メモタイトル -->
      <input
        matInput
        type="text"
        formControlName="title"
        [ngClass]="{
          'invalid-form': checkTitle
        }"
      />
      <!-- メモ -->
      <textarea
        matInput
        formControlName="memo"
        [ngClass]="{
          'invalid-form': checkMemo
        }"
      >
      </textarea>
    </form>
```

#### ボタン配置

```html
  <div class="button-area">
    <div class="left-side">
      .......
    </div>
    <div class="right-side">
      .......
    </div>
  </div>
```

#### スタイル割当

- 各 html タグや、class 属性に割り当てたクラス名を実装します。

#### イベント・呼び出し関数実装

> [!NOTE]
> [NgClass](https://angular.jp/api/common/NgClass)
> [バインディングタイプとターゲット](https://angular.jp/guide/binding-syntax)

- 入力フォームのバリデーション（ todoForm.invalid ）が力エラー状態の場合、`NgClass` を使って赤枠のスタイルを付与します


```html
  <div class="button-area">
    <div class="left-side">
      <!-- click イベントで、 backToList() を呼び出し -->
      <button (click)="backToList()">戻る</button>
    </div>
    <div class="right-side">
      <!-- click イベントで、 saveMemo() を呼び出し -->
      <button
        (click)="saveMemo()"
        [disabled]="todoForm.invalid"
        [ngClass]="{
          'invalid-button': todoForm.invalid
        }"
      >
        保存
      </button>
    </div>
  </div>

```


