### PR TITLE
AP サーバー更新

### DIFF
--- a/backend/my_actix_app/Cargo.toml
+++ b/backend/my_actix_app/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-actix-web = "4.2.1"
+actix-web = "4.5.1"
+actix-cors = "0.7.0"
 mysql = "20.1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/backend/my_actix_app/src/main.rs
+++ b/backend/my_actix_app/src/main.rs
@@ -1,4 +1,5 @@
 use actix_web::{get, post, patch, delete, web, App, HttpRequest, HttpResponse, HttpServer, Responder};
+use actix_cors::Cors;
 use mysql::prelude::*;
 use mysql::*;
 use serde::{Deserialize, Serialize};
@@ -52,7 +53,6 @@ async fn get_memo_by_id(req: HttpRequest) -> impl Responder {
     }
 }
 
-
 #[post("/api/memos")]
 async fn create_memo(req_body: web::Json<Memo>) -> HttpResponse {
     let url = "mysql://ユーザー名:パスワード@ホスト名:3306/データベース名";
@@ -93,6 +93,7 @@ async fn update_memo(id: web::Path<i32>, req_body: web::Json<Memo>) -> HttpRespo
     HttpResponse::Ok().finish()
 }
 
+
 #[delete("/api/memos/{id}")]
 async fn delete_memo(id: web::Path<i32>) -> HttpResponse {
     let memo_id = id.into_inner();
@@ -114,6 +115,16 @@ async fn delete_memo(id: web::Path<i32>) -> HttpResponse {
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     HttpServer::new(|| App::new()
+            .wrap(
+                Cors::default()
+                    .allow_any_origin()
+                    .allowed_methods(vec!["GET", "POST", "OPTIONS"])
+                    .allowed_headers(vec![
+                        "Authorization",
+                        "Accept",
+                    ])
+                    .max_age(3600)
+            )
             .service(get_memos)
             .service(get_memo_by_id)
             .service(create_memo)


### PR DESCRIPTION
## CORS エラー対策で下記作業を実施

### 更新手順

#### rustc を v1.77 にアップデート

```sh
$ rustup update stable
info: syncing channel updates for 'stable-x86_64-unknown-linux-gnu'

  stable-x86_64-unknown-linux-gnu unchanged - rustc 1.77.0 (aedd173a2 2024-03-17)

info: checking for self-update
```

#### 依存関係を最新にするために削除

```sh
$ rm Cargo.lock
```

#### cargo をアップデート

```sh
$ cargo update
```

#### cargo をビルド

```sh
$ cargo build
```

### 更新後の差分

> [!NOTE] 
> [Actix](https://actix.rs/)
> 
> `actix-web`は、Rustの高性能な非同期Webフレームワークであり、Actixプロジェクトの一部です。
> このフレームワークは、高いパフォーマンスと柔軟性を提供し、HTTPサーバーとしての役割を果たします。
> 
> 簡単に言うと、`actix-web`はRustでWebアプリケーションを構築するためのフレームワークであり、HTTPサーバーとして動作します。
> このフレームワークを使用することで、HTTPリクエストを受け取り、処理し、レスポンスを返すWebアプリケーションを作成することができます。
> 
> `actix-web`は非同期I/Oをサポートしており、非同期処理によって複数のリクエストを同時に処理することができます。また、ルーティング、ミドルウェア、リクエスト/レスポンスのハンドリングなど、多くの機能を提供しています。
> 
> [actix_cors](https://docs.rs/actix-cors/latest/actix_cors/)
> `actix-cors`は、RustのWebフレームワークであるActix WebでCORS（Cross - Origin Resource Sharing）を処理するためのミドルウェアです。
> CORSは、異なるオリジン（ドメインやポート番号が異なるサイト）間でのリソース共有を制御するための仕組みであり、ブラウザのセキュリティポリシーに従ってリクエストを制限するために使用されます。
> 
> `actix-cors`を使用すると、Actix WebアプリケーションでCORSポリシーを適切に設定し、クライアントからのリクエストが制限されないようにすることができます。具体的には、異なるオリジンからのリクエストに対するアクセス制御や、リクエストに含まれるヘッダー情報の処理などを簡単に行うことができます。
> 
> 要約すると、`actix-cors`はActix WebアプリケーションでCORSポリシーを処理するためのミドルウェアであり、クライアントとサーバー間の通信を安全に制御するのに役立ちます。

- Cargo.toml

```diff
diff --git a/backend/my_actix_app/Cargo.toml b/backend/my_actix_app/Cargo.toml
index 0e8d515..27021b3 100644
--- a/backend/my_actix_app/Cargo.toml
+++ b/backend/my_actix_app/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 edition = "2018"

 [dependencies]
-actix-web = "4.2.1"
+actix-web = "4.5.1"
+actix-cors = "0.7.0"
 mysql = "20.1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
```

- main.rs


```diff
diff --git a/backend/my_actix_app/src/main.rs b/backend/my_actix_app/src/main.rs
index ead847d..50b427f 100644
--- a/backend/my_actix_app/src/main.rs
+++ b/backend/my_actix_app/src/main.rs
@@ -1,4 +1,5 @@
 use actix_web::{get, post, patch, delete, web, App, HttpRequest, HttpResponse, HttpServer, Responder};
+use actix_cors::Cors;
 use mysql::prelude::*;
 use mysql::*;
 use serde::{Deserialize, Serialize};
@@ -52,7 +53,6 @@ async fn get_memo_by_id(req: HttpRequest) -> impl Responder {
     }
 }

-
 #[post("/api/memos")]
 async fn create_memo(req_body: web::Json<Memo>) -> HttpResponse {
     let url = "mysql://ユーザー名:パスワード@ホスト名:3306/データベース名";
@@ -93,6 +93,7 @@ async fn update_memo(id: web::Path<i32>, req_body: web::Json<Memo>) -> HttpRespo
     HttpResponse::Ok().finish()
 }

+
 #[delete("/api/memos/{id}")]
 async fn delete_memo(id: web::Path<i32>) -> HttpResponse {
     let memo_id = id.into_inner();
@@ -114,6 +115,16 @@ async fn delete_memo(id: web::Path<i32>) -> HttpResponse {
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     HttpServer::new(|| App::new()
+            .wrap(
+                Cors::default()
+                    .allow_any_origin()
+                    .allowed_methods(vec!["GET", "POST", "OPTIONS"])
+                    .allowed_headers(vec![
+                        "Authorization",
+                        "Accept",
+                    ])
+                    .max_age(3600)
+            )
             .service(get_memos)
             .service(get_memo_by_id)
             .service(create_memo)
```

## まとめ

-  上記手順がこのプルリクエストの作業になります。

