### PR TITLE
CORS 解決のための修正

### DIFF
--- a/frontend/proxy.conf.json
+++ b/frontend/proxy.conf.json
@@ -1,6 +1,6 @@
 {
-  "/api/": {
-    "target": "http://ik1-438-51017.vs.sakura.ne.jp/",
+  "/api": {
+    "target": "http://ik1-438-51017.vs.sakura.ne.jp",
     "secure": false,
     "changeOrigin": true
   }

--- a/frontend/src/app/shared/service/api.service.ts
+++ b/frontend/src/app/shared/service/api.service.ts
@@ -13,7 +13,6 @@ export class ApiService {
   httpOptions = {
     headers: new HttpHeaders({
       'Content-Type': 'application/json',
-      'Access-Control-Allow-Origin': '*',
     }),
   };
 


### PR DESCRIPTION
## バックエンド（Rust の AP サーバー）との通信する為の CORS 解決

> [!NOTE] 
> CORS エラーとは？
> 
> CORS（Cross-Origin Resource Sharing）エラーは、ウェブ開発でよく見られる問題の 1 つです。  
> これは、ウェブブラウザーがセキュリティ上の理由から、異なるオリジン（異なるドメイン、プロトコル、またはポート）からのリクエストに制限を設ける仕組みです。
> 
> 具体例
> あなたのウェブサイト example.com から、別のウェブサイト anotherdomain.com にリクエストを送信しようとすると、  
> ブラウザーはセキュリティ上の理由からこれをブロックします。  
> これは、anotherdomain.com のデータを扱う際にセキュリティリスクがあるためです。
> 
> 今回の場合だとウェブサイトが さくら VPS サーバーで、フロントエンド開発する為に Web サーバーの役割を自分のパソコンで行う事を差します。
> [CORS エラー](https://developer.mozilla.org/ja/docs/Web/HTTP/CORS/Errors)

### さくら VPS に構築された Web サーバー（ nginx ）の 設定変更

```sh
# /etc/nginx/sites-available/default を下記のように修正

$ sudo vi /etc/nginx/sites-available/defaul

##
# You should look at the following URL's in order to grasp a solid understanding
# of Nginx configuration files in order to fully unleash the power of Nginx.
# https://www.nginx.com/resources/wiki/start/
# https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls/
# https://wiki.debian.org/Nginx/DirectoryStructure
#
# In most cases, administrators will remove this file from sites-enabled/ and
# leave it as reference inside of sites-available where it will continue to be
# updated by the nginx packaging team.
#
# This file will automatically load configuration files provided by other
# applications, such as Drupal or Wordpress. These applications will be made
# available underneath a path with that package name, such as /drupal8.
#
# Please see /usr/share/doc/nginx-doc/examples/ for more detailed examples.
##

# Default server configuration
#
server {
        listen 80 default_server;
        listen [::]:80 default_server;

        # SSL configuration
        #
        # listen 443 ssl default_server;
        # listen [::]:443 ssl default_server;
        #
        # Note: You should disable gzip for SSL traffic.
        # See: https://bugs.debian.org/773332
        #
        # Read up on ssl_ciphers to ensure a secure configuration.
        # See: https://bugs.debian.org/765782
        #
        # Self signed certs generated by the ssl-cert package
        # Don't use them in a production server!
        #
        # include snippets/snakeoil.conf;

        root /var/www/html;

        # Add index.php to the list if you are using PHP
        index index.html index.htm index.nginx-debian.html;

        server_name _;

        location / {
                # First attempt to serve request as file, then
                # as directory, then fall back to displaying a 404.
                try_files $uri $uri/ =404;
        }

        # pass PHP scripts to FastCGI server
        #
        #location ~ \.php$ {
        #       include snippets/fastcgi-php.conf;
        #
        #       # With php-fpm (or other unix sockets):
        #       fastcgi_pass unix:/run/php/php7.4-fpm.sock;
        #       # With php-cgi (or other tcp sockets):
        #       fastcgi_pass 127.0.0.1:9000;
        #}

        # deny access to .htaccess files, if Apache's document root
        # concurs with nginx's one
        #
        #location ~ /\.ht {
        #       deny all;
        #}

        # 追記箇所 ---------------------------------------
        location /api {
            add_header 'Access-Control-Allow-Methods' 'GET, POST, PATCH, DELETE, OPTIONS';
            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
            add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';

            if ($request_method = 'OPTIONS') {
                add_header 'Access-Control-Allow-Origin' '*';
                add_header 'Access-Control-Allow-Methods' 'GET, POST, PATCH, DELETE, OPTIONS';
                add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
                add_header 'Access-Control-Max-Age' 1728000;
                add_header 'Content-Type' 'text/plain; charset=utf-8';
                add_header 'Content-Length' 0;
                return 204;
            }

            proxy_pass http://127.0.0.1:8080;  # APIサーバーのポート
            proxy_set_header Host $host;
            proxy_set_header X-Real-IP $remote_addr;
        }
        # 追記箇所 ---------------------------------------

}


# Virtual Host configuration for example.com
#
# You can move that to a different file under sites-available/ and symlink that
# to sites-enabled/ to enable it.
#
#server {
#       listen 80;
#       listen [::]:80;
#       server_name example.com;
#
#       root /var/www/example.com;
#       index index.html;
#
#       location / {
#               try_files $uri $uri/ =404;
#       }
#}

```

### Angular アプリケーション（フロントエンド）の proxcy 修正 50fdf09

```diff
diff --git a/frontend/proxy.conf.json b/frontend/proxy.conf.json
index 4492aff..6b10632 100644
--- a/frontend/proxy.conf.json
+++ b/frontend/proxy.conf.json
@@ -1,6 +1,6 @@
 {
-  "/api/": {
-    "target": "http://サーバー名.vs.sakura.ne.jp/",
+  "/api": {
+    "target": "http://サーバー名.vs.sakura.ne.jp",
     "secure": false,
     "changeOrigin": true
   }
```

### 上記変更に伴い、api.service の HTTP ヘッダの削除 256d903
- さくら VPS に構築された Web サーバー（ nginx ）の 設定変更で、Access-Control-Allow-Origin が不要になったので、削除します。

```diff
diff --git a/frontend/src/app/shared/service/api.service.ts b/frontend/src/app/shared/service/api.service.ts
index fe5a229..8f7d460 100644
--- a/frontend/src/app/shared/service/api.service.ts
+++ b/frontend/src/app/shared/service/api.service.ts
@@ -13,7 +13,6 @@ export class ApiService {
   httpOptions = {
     headers: new HttpHeaders({
       'Content-Type': 'application/json',
-      'Access-Control-Allow-Origin': '*',
     }),
   };
```

## まとめ

- 上記手順がこのプルリクエストの作業になります。

