### PR TITLE
フロントエンドの更新 API のURL に id（メモ id）を追加、バックエンドの allowed_methods に patch, delete の追加

### DIFF
--- a/backend/my_actix_app/src/main.rs
+++ b/backend/my_actix_app/src/main.rs
@@ -118,7 +118,7 @@ async fn main() -> std::io::Result<()> {
             .wrap(
                 Cors::default()
                     .allow_any_origin()
-                    .allowed_methods(vec!["GET", "POST", "OPTIONS"])
+                    .allowed_methods(vec!["GET", "POST", "PATCH", "DELETE", "OPTIONS"])
                     .allowed_headers(vec![
                         "Authorization",
                         "Accept",

--- a/frontend/src/app/shared/service/api.service.ts
+++ b/frontend/src/app/shared/service/api.service.ts
@@ -29,7 +29,7 @@ export class ApiService {
   }
 
   update(body: Memo) {
-    return this.http.patch(this.apiUrl, body, this.httpOptions);
+    return this.http.patch(this.apiUrl + `/${body.id}`, body, this.httpOptions);
   }
 
   delete(id: string) {


### PR DESCRIPTION
## フロントエンドの更新 API のURL に id（メモ id）を追加

### フロントエンド側の修正

- api.service.ts
- 更新 API のURL に id（メモ id）不足していたので、 追加

```diff
diff --git a/frontend/src/app/shared/service/api.service.ts b/frontend/src/app/shared/service/api.service.ts
index fe5a229..10a2e54 100644
--- a/frontend/src/app/shared/service/api.service.ts
+++ b/frontend/src/app/shared/service/api.service.ts
@@ -13,7 +13,6 @@ export class ApiService {
   httpOptions = {
     headers: new HttpHeaders({
       'Content-Type': 'application/json',
-      'Access-Control-Allow-Origin': '*',
     }),
   };

@@ -30,7 +29,7 @@ export class ApiService {
   }

   update(body: Memo) {
-    return this.http.patch(this.apiUrl, body, this.httpOptions);
+    return this.http.patch(this.apiUrl + `/${body.id}`, body, this.httpOptions);
   }
```


## バックエンドを allowed_methods に patch, deleteの漏れを追加

### バックエンド側の修正

- main.rs
- バックエンド側の allowed_methods に patch, delete が不足していたので、追加

```diff
diff --git a/backend/my_actix_app/src/main.rs b/backend/my_actix_app/src/main.rs
index 50b427f..4be6ad5 100644
--- a/backend/my_actix_app/src/main.rs
+++ b/backend/my_actix_app/src/main.rs
@@ -118,7 +118,7 @@ async fn main() -> std::io::Result<()> {
             .wrap(
                 Cors::default()
                     .allow_any_origin()
-                    .allowed_methods(vec!["GET", "POST", "OPTIONS"])
+                    .allowed_methods(vec!["GET", "POST", "PATCH", "DELETE", "OPTIONS"])
                     .allowed_headers(vec![
                         "Authorization",
                         "Accept",
```


## まとめ

-  上記手順がこのプルリクエストの作業になります。

